### PR TITLE
Progress bar is needed in production as well

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'devise'
 gem 'faker', :git => 'https://github.com/faker-ruby/faker.git', :branch => 'master'
 gem 'font-awesome-sass'
 gem 'geocoder'
+gem 'progress_bar'
 gem 'pundit'
 gem 'simple_form'
 
@@ -43,7 +44,6 @@ group :development, :test do
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'dotenv-rails'
-  gem 'progress_bar'
 
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]


### PR DESCRIPTION
On Heroku when running seeds:
```
NameError: uninitialized constant ProgressBar
```