### PR TITLE
restore dependent destroy

### DIFF
--- a/app/models/experience.rb
+++ b/app/models/experience.rb
@@ -1,8 +1,8 @@
 class Experience < ApplicationRecord
   belongs_to :user
   has_many_attached :photos # Should 2-4 photos
-  has_many :bookings
-  has_many :reviews
+  has_many :bookings, dependent: :destroy
+  has_many :reviews, dependent: :destroy
   validates :name, presence: true
   validates :price, presence: true
   validates :start_time, presence: true


### PR DESCRIPTION
Seems like the `dependent: destroy` was mistakenly removed in #36 when solving conflicts.

Creating a new PR to restore it.